### PR TITLE
Add Modem Simulation Mode

### DIFF
--- a/Sources/AnsiSaver/Animator.swift
+++ b/Sources/AnsiSaver/Animator.swift
@@ -25,6 +25,7 @@ class Animator {
         case displaying(until: CFTimeInterval)
         case endPause(until: CFTimeInterval)
         case continuousScrolling
+        case modemRevealing
     }
 
     private var phase: Phase = .idle
@@ -36,6 +37,20 @@ class Animator {
     private var scrollOffset: CGFloat = 0
     private var viewSize: NSSize = .zero
     private var pendingNextArt = false
+
+    // Modem simulation state
+    private var modemCharPosition: CGFloat = 0
+    private var modemColumns: Int = 80
+    private var modemRows: Int = 25
+    private var modemDisplayCharWidth: CGFloat = 0
+    private var modemDisplayCharHeight: CGFloat = 0
+    private var modemCharsPerFrame: CGFloat = 0
+    private var modemTotalChars: Int = 0
+    private var modemMaskLayer: CAShapeLayer?
+    private var modemFitHeight: CGFloat = 0
+    private var modemContentCols: [Int] = []      // actual content width per row
+    private var modemCumulativeChars: [Int] = []  // cumulative char offsets per row
+    private var modemImageStartY: CGFloat = 0     // top of current image in content stack
 
     var onAnimationComplete: (() -> Void)?
     var onNeedNextArt: ((_ callback: @escaping (NSImage, String) -> Void) -> Void)?
@@ -114,6 +129,219 @@ class Animator {
         } else {
             phase = .startPause(until: CACurrentMediaTime() + 2.0)
         }
+    }
+
+    // MARK: - Modem simulation mode
+
+    func displayModem(image: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: Int, viewSize: NSSize) {
+        guard let container = containerLayer else { return }
+        self.viewSize = viewSize
+
+        stopAnimations()
+
+        let imageSize = image.size
+        let scaleX = viewSize.width / imageSize.width
+        let fitWidth = imageSize.width * scaleX
+        let fitHeight = imageSize.height * scaleX
+
+        let newLayer = CALayer()
+        newLayer.contents = image
+        newLayer.contentsGravity = .resize
+        newLayer.frame = CGRect(
+            x: (viewSize.width - fitWidth) / 2,
+            y: 0,
+            width: fitWidth,
+            height: fitHeight
+        )
+
+        // Position image with top at top of view
+        newLayer.position = CGPoint(
+            x: newLayer.frame.midX,
+            y: viewSize.height - fitHeight / 2
+        )
+
+        // Create mask layer (initially empty — nothing visible)
+        let mask = CAShapeLayer()
+        mask.frame = newLayer.bounds
+        newLayer.mask = mask
+
+        container.addSublayer(newLayer)
+        currentLayer = newLayer
+        modemMaskLayer = mask
+
+        modemColumns = max(columns, 1)
+        modemRows = max(rows, 1)
+        modemDisplayCharWidth = fitWidth / CGFloat(modemColumns)
+        modemDisplayCharHeight = fitHeight / CGFloat(modemRows)
+        modemCharsPerFrame = CGFloat(modemSpeed) / 10.0 / 60.0
+        modemCharPosition = 0
+        modemFitHeight = fitHeight
+
+        // Build per-row content widths and cumulative char offsets.
+        // Each row costs max(contentCols, 1) effective chars — the 1 accounts
+        // for CR/LF on fully empty rows.
+        modemContentCols = contentColumnsPerRow
+        modemCumulativeChars = [Int](repeating: 0, count: modemRows + 1)
+        for r in 0..<modemRows {
+            let rowChars = r < modemContentCols.count ? max(modemContentCols[r], 1) : modemColumns
+            modemCumulativeChars[r + 1] = modemCumulativeChars[r] + rowChars
+        }
+        modemTotalChars = modemCumulativeChars[modemRows]
+
+        phase = .startPause(until: CACurrentMediaTime() + 1.0)
+    }
+
+    func startModemContinuous(firstImage: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: Int, viewSize: NSSize) {
+        guard let container = containerLayer else { return }
+        self.viewSize = viewSize
+
+        stopAnimations()
+
+        let content = CALayer()
+        content.masksToBounds = false
+        container.addSublayer(content)
+        contentLayer = content
+
+        nextContentY = 0
+        scrollOffset = 0
+        stackedLayers = []
+        pendingNextArt = false
+
+        modemCharsPerFrame = CGFloat(modemSpeed) / 10.0 / 60.0
+
+        appendModemArt(image: firstImage, columns: columns, rows: rows, contentColumnsPerRow: contentColumnsPerRow)
+        phase = .startPause(until: CACurrentMediaTime() + 1.0)
+    }
+
+    func appendModemArt(image: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int]) {
+        guard let content = contentLayer else { return }
+
+        let imageSize = image.size
+        let scaleX = viewSize.width / imageSize.width
+        let fitWidth = imageSize.width * scaleX
+        let fitHeight = imageSize.height * scaleX
+
+        let artLayer = CALayer()
+        artLayer.contents = image
+        artLayer.contentsGravity = .resize
+        artLayer.frame = CGRect(
+            x: (viewSize.width - fitWidth) / 2,
+            y: -nextContentY - fitHeight,
+            width: fitWidth,
+            height: fitHeight
+        )
+
+        let mask = CAShapeLayer()
+        mask.frame = artLayer.bounds
+        artLayer.mask = mask
+
+        content.addSublayer(artLayer)
+
+        modemImageStartY = nextContentY
+        let bottomY = nextContentY + fitHeight
+        stackedLayers.append((layer: artLayer, bottomY: bottomY))
+        nextContentY = bottomY
+
+        currentLayer = artLayer
+        modemMaskLayer = mask
+        modemColumns = max(columns, 1)
+        modemRows = max(rows, 1)
+        modemDisplayCharWidth = fitWidth / CGFloat(modemColumns)
+        modemDisplayCharHeight = fitHeight / CGFloat(modemRows)
+        modemCharPosition = 0
+        modemFitHeight = fitHeight
+
+        modemContentCols = contentColumnsPerRow
+        modemCumulativeChars = [Int](repeating: 0, count: modemRows + 1)
+        for r in 0..<modemRows {
+            let rowChars = r < modemContentCols.count ? max(modemContentCols[r], 1) : modemColumns
+            modemCumulativeChars[r + 1] = modemCumulativeChars[r] + rowChars
+        }
+        modemTotalChars = modemCumulativeChars[modemRows]
+
+        pendingNextArt = false
+        phase = .modemRevealing
+    }
+
+    private func tickModemReveal() {
+        guard let layer = currentLayer, let mask = modemMaskLayer else {
+            phase = .idle
+            return
+        }
+
+        modemCharPosition += modemCharsPerFrame
+        let charIndex = min(Int(modemCharPosition), modemTotalChars)
+
+        if charIndex >= modemTotalChars {
+            // Fully revealed — remove mask, pause with jitter before next file
+            layer.mask = nil
+            modemMaskLayer = nil
+            let jitter = Double.random(in: 0...1.0)
+            phase = .endPause(until: CACurrentMediaTime() + 2.0 + jitter)
+            return
+        }
+
+        // Map linear char position to (row, col) using cumulative offsets.
+        // Each row has a variable effective width based on actual content.
+        var row = 0
+        for r in 0..<modemRows {
+            if charIndex < modemCumulativeChars[r + 1] {
+                row = r
+                break
+            }
+        }
+        let colInRow = charIndex - modemCumulativeChars[row]
+        // Clamp col to the content width for this row (the extra 1 for CR/LF
+        // shouldn't extend the visible reveal beyond the content)
+        let rowContent = row < modemContentCols.count ? modemContentCols[row] : modemColumns
+        let col = min(colInRow, rowContent)
+
+        let dch = modemDisplayCharHeight
+        let dcw = modemDisplayCharWidth
+        let fitHeight = modemFitHeight
+        let fitWidth = layer.bounds.width
+
+        // Build reveal mask path
+        let path = CGMutablePath()
+
+        // Fully revealed rows above current row (full width — trailing black
+        // is already black, so revealing it is invisible)
+        if row > 0 {
+            path.addRect(CGRect(
+                x: 0,
+                y: fitHeight - CGFloat(row) * dch,
+                width: fitWidth,
+                height: CGFloat(row) * dch
+            ))
+        }
+
+        // Partial current row
+        if col > 0 {
+            path.addRect(CGRect(
+                x: 0,
+                y: fitHeight - CGFloat(row + 1) * dch,
+                width: CGFloat(col) * dcw,
+                height: dch
+            ))
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        mask.path = path
+
+        // Scroll content layer to keep cursor visible
+        if let content = contentLayer {
+            let cursorAbsY = modemImageStartY + CGFloat(row + 1) * dch
+            content.bounds.origin.y = -max(viewSize.height, cursorAbsY)
+            scrollOffset = max(0, cursorAbsY - viewSize.height)
+
+            // Remove layers that scrolled off the top
+            while let first = stackedLayers.first, first.bottomY < scrollOffset {
+                first.layer.removeFromSuperlayer()
+                stackedLayers.removeFirst()
+            }
+        }
+        CATransaction.commit()
     }
 
     // MARK: - Continuous scroll mode
@@ -250,7 +478,9 @@ class Animator {
             if CACurrentMediaTime() >= until {
                 oldLayer?.removeFromSuperlayer()
                 oldLayer = nil
-                if contentLayer != nil {
+                if modemMaskLayer != nil {
+                    phase = .modemRevealing
+                } else if contentLayer != nil {
                     phase = .continuousScrolling
                 } else {
                     phase = .scrolling
@@ -281,6 +511,9 @@ class Animator {
                 layer.position.y = newY
             }
             CATransaction.commit()
+
+        case .modemRevealing:
+            tickModemReveal()
 
         case .continuousScrolling:
             guard let content = contentLayer else {
@@ -337,6 +570,8 @@ class Animator {
         contentLayer = nil
         stackedLayers = []
         pendingNextArt = false
+        modemMaskLayer = nil
+        modemImageStartY = 0
         phase = .idle
     }
 }

--- a/Sources/AnsiSaver/Animator.swift
+++ b/Sources/AnsiSaver/Animator.swift
@@ -7,6 +7,52 @@ enum TransitionMode: Int {
     case crossfade = 2
 }
 
+struct ModemRevealState {
+    var charPosition: CGFloat = 0
+    var columns: Int = 80
+    var rows: Int = 25
+    var displayCharWidth: CGFloat = 0
+    var displayCharHeight: CGFloat = 0
+    var charsPerFrame: CGFloat = 0
+    var totalChars: Int = 0
+    var maskLayer: CAShapeLayer?
+    var fitHeight: CGFloat = 0
+    var contentCols: [Int] = []
+    /// Prefix-sum of effective char counts; has rows+1 elements.
+    var cumulativeChars: [Int] = []
+    /// Y offset where current image begins in the content stack.
+    var imageStartY: CGFloat = 0
+
+    /// Build cumulative char offsets from per-row content widths.
+    /// Each row costs max(contentCols, 1) effective chars — the 1 accounts
+    /// for CR/LF on fully empty rows.
+    mutating func buildCumulativeChars() {
+        cumulativeChars = [Int](repeating: 0, count: rows + 1)
+        for r in 0..<rows {
+            let rowChars = r < contentCols.count ? max(contentCols[r], 1) : columns
+            cumulativeChars[r + 1] = cumulativeChars[r] + rowChars
+        }
+        totalChars = cumulativeChars[rows]
+    }
+
+    /// Map a linear character index to (row, col) using cumulative offsets.
+    func rowAndColumn(forCharIndex charIndex: Int) -> (row: Int, col: Int) {
+        var row = 0
+        for r in 0..<rows {
+            if charIndex < cumulativeChars[r + 1] {
+                row = r
+                break
+            }
+        }
+        let colInRow = charIndex - cumulativeChars[row]
+        // Clamp col to the content width for this row (the extra 1 for CR/LF
+        // shouldn't extend the visible reveal beyond the content)
+        let rowContent = row < contentCols.count ? contentCols[row] : columns
+        let col = min(colInRow, rowContent)
+        return (row, col)
+    }
+}
+
 class Animator {
 
     private weak var containerLayer: CALayer?
@@ -39,18 +85,7 @@ class Animator {
     private var pendingNextArt = false
 
     // Modem simulation state
-    private var modemCharPosition: CGFloat = 0
-    private var modemColumns: Int = 80
-    private var modemRows: Int = 25
-    private var modemDisplayCharWidth: CGFloat = 0
-    private var modemDisplayCharHeight: CGFloat = 0
-    private var modemCharsPerFrame: CGFloat = 0
-    private var modemTotalChars: Int = 0
-    private var modemMaskLayer: CAShapeLayer?
-    private var modemFitHeight: CGFloat = 0
-    private var modemContentCols: [Int] = []      // actual content width per row
-    private var modemCumulativeChars: [Int] = []  // cumulative char offsets per row
-    private var modemImageStartY: CGFloat = 0     // top of current image in content stack
+    private var modemState = ModemRevealState()
 
     var onAnimationComplete: (() -> Void)?
     var onNeedNextArt: ((_ callback: @escaping (NSImage, String) -> Void) -> Void)?
@@ -63,7 +98,10 @@ class Animator {
     // MARK: - Standard mode
 
     func display(image: NSImage, transition: TransitionMode, speed: Double, viewSize: NSSize) {
-        guard let container = containerLayer else { return }
+        guard let container = containerLayer else {
+            Configuration.debugLog("display: containerLayer is nil")
+            return
+        }
         self.viewSize = viewSize
 
         let imageSize = image.size
@@ -133,66 +171,11 @@ class Animator {
 
     // MARK: - Modem simulation mode
 
-    func displayModem(image: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: Int, viewSize: NSSize) {
-        guard let container = containerLayer else { return }
-        self.viewSize = viewSize
-
-        stopAnimations()
-
-        let imageSize = image.size
-        let scaleX = viewSize.width / imageSize.width
-        let fitWidth = imageSize.width * scaleX
-        let fitHeight = imageSize.height * scaleX
-
-        let newLayer = CALayer()
-        newLayer.contents = image
-        newLayer.contentsGravity = .resize
-        newLayer.frame = CGRect(
-            x: (viewSize.width - fitWidth) / 2,
-            y: 0,
-            width: fitWidth,
-            height: fitHeight
-        )
-
-        // Position image with top at top of view
-        newLayer.position = CGPoint(
-            x: newLayer.frame.midX,
-            y: viewSize.height - fitHeight / 2
-        )
-
-        // Create mask layer (initially empty — nothing visible)
-        let mask = CAShapeLayer()
-        mask.frame = newLayer.bounds
-        newLayer.mask = mask
-
-        container.addSublayer(newLayer)
-        currentLayer = newLayer
-        modemMaskLayer = mask
-
-        modemColumns = max(columns, 1)
-        modemRows = max(rows, 1)
-        modemDisplayCharWidth = fitWidth / CGFloat(modemColumns)
-        modemDisplayCharHeight = fitHeight / CGFloat(modemRows)
-        modemCharsPerFrame = CGFloat(modemSpeed) / 10.0 / 60.0
-        modemCharPosition = 0
-        modemFitHeight = fitHeight
-
-        // Build per-row content widths and cumulative char offsets.
-        // Each row costs max(contentCols, 1) effective chars — the 1 accounts
-        // for CR/LF on fully empty rows.
-        modemContentCols = contentColumnsPerRow
-        modemCumulativeChars = [Int](repeating: 0, count: modemRows + 1)
-        for r in 0..<modemRows {
-            let rowChars = r < modemContentCols.count ? max(modemContentCols[r], 1) : modemColumns
-            modemCumulativeChars[r + 1] = modemCumulativeChars[r] + rowChars
+    func startModemContinuous(firstImage: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: ModemSpeed, viewSize: NSSize) {
+        guard let container = containerLayer else {
+            Configuration.debugLog("startModemContinuous: containerLayer is nil")
+            return
         }
-        modemTotalChars = modemCumulativeChars[modemRows]
-
-        phase = .startPause(until: CACurrentMediaTime() + 1.0)
-    }
-
-    func startModemContinuous(firstImage: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: Int, viewSize: NSSize) {
-        guard let container = containerLayer else { return }
         self.viewSize = viewSize
 
         stopAnimations()
@@ -207,14 +190,18 @@ class Animator {
         stackedLayers = []
         pendingNextArt = false
 
-        modemCharsPerFrame = CGFloat(modemSpeed) / 10.0 / 60.0
+        modemState.charsPerFrame = modemSpeed.charsPerFrame
 
         appendModemArt(image: firstImage, columns: columns, rows: rows, contentColumnsPerRow: contentColumnsPerRow)
         phase = .startPause(until: CACurrentMediaTime() + 1.0)
     }
 
     func appendModemArt(image: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int]) {
-        guard let content = contentLayer else { return }
+        guard let content = contentLayer else {
+            Configuration.debugLog("appendModemArt: contentLayer is nil, firing completion")
+            onAnimationComplete?()
+            return
+        }
 
         let imageSize = image.size
         let scaleX = viewSize.width / imageSize.width
@@ -231,81 +218,70 @@ class Animator {
             height: fitHeight
         )
 
+        // Create mask layer (initially empty — nothing visible)
         let mask = CAShapeLayer()
         mask.frame = artLayer.bounds
         artLayer.mask = mask
 
         content.addSublayer(artLayer)
 
-        modemImageStartY = nextContentY
+        modemState.imageStartY = nextContentY
         let bottomY = nextContentY + fitHeight
         stackedLayers.append((layer: artLayer, bottomY: bottomY))
         nextContentY = bottomY
 
         currentLayer = artLayer
-        modemMaskLayer = mask
-        modemColumns = max(columns, 1)
-        modemRows = max(rows, 1)
-        modemDisplayCharWidth = fitWidth / CGFloat(modemColumns)
-        modemDisplayCharHeight = fitHeight / CGFloat(modemRows)
-        modemCharPosition = 0
-        modemFitHeight = fitHeight
-
-        modemContentCols = contentColumnsPerRow
-        modemCumulativeChars = [Int](repeating: 0, count: modemRows + 1)
-        for r in 0..<modemRows {
-            let rowChars = r < modemContentCols.count ? max(modemContentCols[r], 1) : modemColumns
-            modemCumulativeChars[r + 1] = modemCumulativeChars[r] + rowChars
-        }
-        modemTotalChars = modemCumulativeChars[modemRows]
+        modemState.maskLayer = mask
+        modemState.columns = max(columns, 1)
+        modemState.rows = max(rows, 1)
+        modemState.displayCharWidth = fitWidth / CGFloat(modemState.columns)
+        modemState.displayCharHeight = fitHeight / CGFloat(modemState.rows)
+        modemState.charPosition = 0
+        modemState.fitHeight = fitHeight
+        modemState.contentCols = contentColumnsPerRow
+        modemState.buildCumulativeChars()
 
         pendingNextArt = false
         phase = .modemRevealing
     }
 
     private func tickModemReveal() {
-        guard let layer = currentLayer, let mask = modemMaskLayer else {
+        guard let layer = currentLayer, let mask = modemState.maskLayer else {
+            Configuration.debugLog("tickModemReveal: lost layer or mask reference")
             phase = .idle
+            onAnimationComplete?()
             return
         }
 
-        modemCharPosition += modemCharsPerFrame
-        let charIndex = min(Int(modemCharPosition), modemTotalChars)
+        modemState.charPosition += modemState.charsPerFrame
+        let charIndex = min(Int(modemState.charPosition), modemState.totalChars)
 
-        if charIndex >= modemTotalChars {
+        if charIndex >= modemState.totalChars {
             // Fully revealed — remove mask, pause with jitter before next file
             layer.mask = nil
-            modemMaskLayer = nil
+            modemState.maskLayer = nil
             let jitter = Double.random(in: 0...1.0)
             phase = .endPause(until: CACurrentMediaTime() + 2.0 + jitter)
+            // Prefetch next art during the pause so there's no stall
+            if !pendingNextArt {
+                pendingNextArt = true
+                onAnimationComplete?()
+            }
             return
         }
 
-        // Map linear char position to (row, col) using cumulative offsets.
-        // Each row has a variable effective width based on actual content.
-        var row = 0
-        for r in 0..<modemRows {
-            if charIndex < modemCumulativeChars[r + 1] {
-                row = r
-                break
-            }
-        }
-        let colInRow = charIndex - modemCumulativeChars[row]
-        // Clamp col to the content width for this row (the extra 1 for CR/LF
-        // shouldn't extend the visible reveal beyond the content)
-        let rowContent = row < modemContentCols.count ? modemContentCols[row] : modemColumns
-        let col = min(colInRow, rowContent)
+        let (row, col) = modemState.rowAndColumn(forCharIndex: charIndex)
 
-        let dch = modemDisplayCharHeight
-        let dcw = modemDisplayCharWidth
-        let fitHeight = modemFitHeight
+        let dch = modemState.displayCharHeight
+        let dcw = modemState.displayCharWidth
+        let fitHeight = modemState.fitHeight
         let fitWidth = layer.bounds.width
 
         // Build reveal mask path
         let path = CGMutablePath()
 
-        // Fully revealed rows above current row (full width — trailing black
-        // is already black, so revealing it is invisible)
+        // Fully revealed rows: use full width since trailing empty columns
+        // are black pixels on a black background, making the reveal invisible
         if row > 0 {
             path.addRect(CGRect(
                 x: 0,
@@ -331,7 +307,7 @@ class Animator {
 
         // Scroll content layer to keep cursor visible
         if let content = contentLayer {
-            let cursorAbsY = modemImageStartY + CGFloat(row + 1) * dch
+            let cursorAbsY = modemState.imageStartY + CGFloat(row + 1) * dch
             content.bounds.origin.y = -max(viewSize.height, cursorAbsY)
             scrollOffset = max(0, cursorAbsY - viewSize.height)
 
@@ -347,7 +323,10 @@ class Animator {
     // MARK: - Continuous scroll mode
 
     func startContinuousScroll(firstImage: NSImage, fileName: String, speed: Double, viewSize: NSSize, showSeparator: Bool) {
-        guard let container = containerLayer else { return }
+        guard let container = containerLayer else {
+            Configuration.debugLog("startContinuousScroll: containerLayer is nil")
+            return
+        }
         self.viewSize = viewSize
         scrollSpeed = CGFloat(max(speed, 1))
 
@@ -478,7 +457,7 @@ class Animator {
             if CACurrentMediaTime() >= until {
                 oldLayer?.removeFromSuperlayer()
                 oldLayer = nil
-                if modemMaskLayer != nil {
+                if modemState.maskLayer != nil {
                     phase = .modemRevealing
                 } else if contentLayer != nil {
                     phase = .continuousScrolling
@@ -489,7 +468,9 @@ class Animator {
 
         case .scrolling:
             guard let layer = currentLayer else {
+                Configuration.debugLog("tick scrolling: currentLayer is nil")
                 phase = .idle
+                onAnimationComplete?()
                 return
             }
             let step = scrollSpeed / 60.0 * scrollDirection
@@ -517,7 +498,9 @@ class Animator {
 
         case .continuousScrolling:
             guard let content = contentLayer else {
+                Configuration.debugLog("tick continuousScrolling: contentLayer is nil")
                 phase = .idle
+                onAnimationComplete?()
                 return
             }
 
@@ -556,7 +539,9 @@ class Animator {
         case .endPause(let until):
             if CACurrentMediaTime() >= until {
                 phase = .idle
-                onAnimationComplete?()
+                if !pendingNextArt {
+                    onAnimationComplete?()
+                }
             }
         }
     }
@@ -570,8 +555,7 @@ class Animator {
         contentLayer = nil
         stackedLayers = []
         pendingNextArt = false
-        modemMaskLayer = nil
-        modemImageStartY = 0
+        modemState = ModemRevealState()
         phase = .idle
     }
 }

--- a/Sources/AnsiSaver/Animator.swift
+++ b/Sources/AnsiSaver/Animator.swift
@@ -22,6 +22,11 @@ struct ModemRevealState {
     var cumulativeChars: [Int] = []
     /// Y offset where current image begins in the content stack.
     var imageStartY: CGFloat = 0
+    /// Cursor blink frame counter.
+    var blinkCounter: Int = 0
+    var cursorVisible: Bool = true
+    /// Frames remaining in current line-noise stall (0 = normal flow).
+    var stallFramesRemaining: Int = 0
 
     /// Build cumulative char offsets from per-row content widths.
     /// Each row costs max(contentCols, 1) effective chars — the 1 accounts
@@ -72,6 +77,8 @@ class Animator {
         case endPause(until: CFTimeInterval)
         case continuousScrolling
         case modemRevealing
+        /// Brief hold after file completes, before the line-feed jump.
+        case modemEndHold(until: CFTimeInterval)
     }
 
     private var phase: Phase = .idle
@@ -86,6 +93,19 @@ class Animator {
 
     // Modem simulation state
     private var modemState = ModemRevealState()
+
+    // Modem cursor
+    private var cursorLayer: CALayer?
+    /// IBM PC BIOS default: toggle every 8 timer ticks at 18.2 Hz ≈ 440ms half-cycle.
+    private static let cursorBlinkHalfCycle = 26
+    /// Pre-computed state for the end-hold line-feed jump.
+    private var modemHoldScrollOriginY: CGFloat = 0
+    private var modemHoldContentY: CGFloat = 0
+    private var loadingLayer: CALayer?
+    private var modemScaleFactor: UInt8 = 0
+
+    /// Filename of the next art file (set by the view for the loading message).
+    var nextFileName: String?
 
     var onAnimationComplete: (() -> Void)?
     var onNeedNextArt: ((_ callback: @escaping (NSImage, String) -> Void) -> Void)?
@@ -171,7 +191,7 @@ class Animator {
 
     // MARK: - Modem simulation mode
 
-    func startModemContinuous(firstImage: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: ModemSpeed, viewSize: NSSize) {
+    func startModemContinuous(firstImage: NSImage, columns: Int, rows: Int, contentColumnsPerRow: [Int], modemSpeed: ModemSpeed, scaleFactor: UInt8, viewSize: NSSize) {
         guard let container = containerLayer else {
             Configuration.debugLog("startModemContinuous: containerLayer is nil")
             return
@@ -191,6 +211,11 @@ class Animator {
         pendingNextArt = false
 
         modemState.charsPerFrame = modemSpeed.charsPerFrame
+        modemScaleFactor = scaleFactor
+
+        let cursor = createCursorLayer()
+        content.addSublayer(cursor)
+        cursorLayer = cursor
 
         appendModemArt(image: firstImage, columns: columns, rows: rows, contentColumnsPerRow: contentColumnsPerRow)
         phase = .startPause(until: CACurrentMediaTime() + 1.0)
@@ -201,6 +226,11 @@ class Animator {
             Configuration.debugLog("appendModemArt: contentLayer is nil, firing completion")
             onAnimationComplete?()
             return
+        }
+
+        // Add blank line gap between consecutive files
+        if nextContentY > 0 {
+            nextContentY += 2.0 * modemState.displayCharHeight
         }
 
         let imageSize = image.size
@@ -242,7 +272,81 @@ class Animator {
         modemState.buildCumulativeChars()
 
         pendingNextArt = false
-        phase = .modemRevealing
+        // Don't override hold or pause — let them expire naturally
+        switch phase {
+        case .modemEndHold, .endPause:
+            break
+        default:
+            updateCursorPosition(row: 0, col: 0)
+            phase = .modemRevealing
+        }
+    }
+
+    // MARK: - Modem cursor
+
+    private func createCursorLayer() -> CALayer {
+        let cursor = CALayer()
+        // DOS color 7 (light gray): RGB(170, 170, 170)
+        let cursorColor = NSColor(white: 0.667, alpha: 1.0).cgColor
+        cursor.backgroundColor = cursorColor
+        cursor.zPosition = 1000
+        // Subtle CRT phosphor glow
+        cursor.shadowColor = cursorColor
+        cursor.shadowOffset = .zero
+        cursor.shadowRadius = 2.0
+        cursor.shadowOpacity = 0.5
+        return cursor
+    }
+
+    private func updateCursorPosition(row: Int, col: Int) {
+        guard let cursor = cursorLayer else { return }
+        let dcw = modemState.displayCharWidth
+        let dch = modemState.displayCharHeight
+        let artX = currentLayer?.frame.origin.x ?? 0
+        // Bottom 2 scan lines of a 16-line character cell
+        let underscoreHeight = max(dch * 2.0 / 16.0, 1.0)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursor.frame = CGRect(
+            x: artX + CGFloat(col) * dcw,
+            y: -modemState.imageStartY - CGFloat(row + 1) * dch,
+            width: dcw,
+            height: underscoreHeight
+        )
+        CATransaction.commit()
+    }
+
+    /// Hide cursor during reveal; blink it during pauses.
+    private func tickCursorBlink() {
+        guard let cursor = cursorLayer else { return }
+
+        switch phase {
+        case .modemRevealing, .modemEndHold:
+            // Hide cursor during reveal and the brief hold after
+            if modemState.cursorVisible {
+                modemState.cursorVisible = false
+                CATransaction.begin()
+                CATransaction.setDisableActions(true)
+                cursor.isHidden = true
+                CATransaction.commit()
+            }
+            modemState.blinkCounter = 0
+            return
+        default:
+            break
+        }
+
+        // Blink during pauses (startPause, endPause, idle)
+        modemState.blinkCounter += 1
+        if modemState.blinkCounter >= Self.cursorBlinkHalfCycle {
+            modemState.blinkCounter = 0
+            modemState.cursorVisible.toggle()
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            cursor.isHidden = !modemState.cursorVisible
+            CATransaction.commit()
+        }
     }
 
     private func tickModemReveal() {
@@ -253,16 +357,38 @@ class Animator {
             return
         }
 
+        // Simulate analog line noise: stalls from retransmission and flow control
+        if modemState.stallFramesRemaining > 0 {
+            modemState.stallFramesRemaining -= 1
+            return
+        }
+        let roll = Int.random(in: 0..<1000)
+        if roll < 2 {
+            // ~0.2% per frame: V.42 error-correction retransmit (corrupted frame on a noisy line)
+            modemState.stallFramesRemaining = Int.random(in: 15...40)
+            return
+        } else if roll < 12 {
+            // ~1% per frame: XON/XOFF flow-control pause (receiver buffer pressure)
+            modemState.stallFramesRemaining = Int.random(in: 2...6)
+            return
+        }
+
         modemState.charPosition += modemState.charsPerFrame
         let charIndex = min(Int(modemState.charPosition), modemState.totalChars)
 
         if charIndex >= modemState.totalChars {
-            // Fully revealed — remove mask, pause with jitter before next file
+            // Pre-compute cursor, scroll, and content position for the line-feed
+            // jump (before appendModemArt can overwrite modemState with the next image).
+            let cursorRow = modemState.rows
+            updateCursorPosition(row: cursorRow, col: 0)
+            let cursorAbsY = modemState.imageStartY + CGFloat(cursorRow + 1) * modemState.displayCharHeight
+            modemHoldScrollOriginY = -max(viewSize.height, cursorAbsY)
+            modemHoldContentY = modemState.imageStartY + modemState.fitHeight
+            // Fully revealed — remove mask, hold briefly before line-feed jump
             layer.mask = nil
             modemState.maskLayer = nil
-            let jitter = Double.random(in: 0...1.0)
-            phase = .endPause(until: CACurrentMediaTime() + 2.0 + jitter)
-            // Prefetch next art during the pause so there's no stall
+            phase = .modemEndHold(until: CACurrentMediaTime() + 1.0)
+            // Prefetch next art during the hold so there's no stall
             if !pendingNextArt {
                 pendingNextArt = true
                 onAnimationComplete?()
@@ -317,6 +443,7 @@ class Animator {
                 stackedLayers.removeFirst()
             }
         }
+
         CATransaction.commit()
     }
 
@@ -429,6 +556,8 @@ class Animator {
     // MARK: - Tick
 
     func tick() {
+        tickCursorBlink()
+
         switch phase {
         case .idle:
             return
@@ -496,6 +625,58 @@ class Animator {
         case .modemRevealing:
             tickModemReveal()
 
+        case .modemEndHold(let until):
+            if CACurrentMediaTime() >= until {
+                CATransaction.begin()
+                CATransaction.setDisableActions(true)
+
+                // Render and display "Loading filename..." if we know the next file
+                if let name = nextFileName,
+                   let (loadImage, cursorCol) = Renderer.renderLoadingMessage(
+                       fileName: name, scaleFactor: modemScaleFactor),
+                   let content = contentLayer {
+                    let scaleX = viewSize.width / loadImage.size.width
+                    let fitWidth = loadImage.size.width * scaleX
+                    let fitHeight = loadImage.size.height * scaleX
+
+                    let layer = CALayer()
+                    layer.contents = loadImage
+                    layer.contentsGravity = .resize
+                    layer.frame = CGRect(
+                        x: (viewSize.width - fitWidth) / 2,
+                        y: -modemHoldContentY - fitHeight,
+                        width: fitWidth,
+                        height: fitHeight
+                    )
+                    content.addSublayer(layer)
+                    loadingLayer = layer
+
+                    // Position cursor after the text
+                    let dcw = fitWidth / 80.0
+                    let underscoreHeight = max(fitHeight * 2.0 / 16.0, 1.0)
+                    cursorLayer?.frame = CGRect(
+                        x: (viewSize.width - fitWidth) / 2 + CGFloat(cursorCol) * dcw,
+                        y: -modemHoldContentY - fitHeight,
+                        width: dcw,
+                        height: underscoreHeight
+                    )
+                    nextFileName = nil
+                }
+
+                // Instant line-feed jump using pre-computed scroll
+                modemState.blinkCounter = 0
+                modemState.cursorVisible = true
+                cursorLayer?.isHidden = false
+                if let content = contentLayer {
+                    content.bounds.origin.y = modemHoldScrollOriginY
+                    scrollOffset = max(0, -modemHoldScrollOriginY - viewSize.height)
+                }
+                CATransaction.commit()
+
+                let jitter = Double.random(in: 0...2.0)
+                phase = .endPause(until: CACurrentMediaTime() + 1.0 + jitter)
+            }
+
         case .continuousScrolling:
             guard let content = contentLayer else {
                 Configuration.debugLog("tick continuousScrolling: contentLayer is nil")
@@ -538,15 +719,26 @@ class Animator {
 
         case .endPause(let until):
             if CACurrentMediaTime() >= until {
-                phase = .idle
-                if !pendingNextArt {
-                    onAnimationComplete?()
+                loadingLayer?.removeFromSuperlayer()
+                loadingLayer = nil
+                if modemState.maskLayer != nil {
+                    // Next modem art was pre-loaded during the pause
+                    phase = .modemRevealing
+                } else {
+                    phase = .idle
+                    if !pendingNextArt {
+                        onAnimationComplete?()
+                    }
                 }
             }
         }
     }
 
     func stopAnimations() {
+        loadingLayer?.removeFromSuperlayer()
+        loadingLayer = nil
+        cursorLayer?.removeFromSuperlayer()
+        cursorLayer = nil
         currentLayer?.removeFromSuperlayer()
         oldLayer?.removeFromSuperlayer()
         contentLayer?.removeFromSuperlayer()

--- a/Sources/AnsiSaver/AnsiSaverView.swift
+++ b/Sources/AnsiSaver/AnsiSaverView.swift
@@ -143,12 +143,10 @@ class AnsiSaverView: ScreenSaverView {
                 return
             }
 
-            // For modem mode, compute content columns per row on background thread
+            // For modem mode, compute content columns per row on background thread (pixel scanning is expensive)
             let modemInfo: (columns: Int, rows: Int, contentCols: [Int])?
             if useModem, let result = renderResult {
-                let effectiveScale = max(Int(sf), 1)
-                let columns = result.pixelWidth / (8 * effectiveScale)
-                let rows = result.pixelHeight / (16 * effectiveScale)
+                let (columns, rows) = result.gridSize(scaleFactor: Int(sf))
                 let contentCols = Renderer.contentColumnsPerRow(for: result, columns: columns, rows: rows)
                 modemInfo = (columns, rows, contentCols)
             } else {
@@ -234,9 +232,7 @@ class AnsiSaverView: ScreenSaverView {
                 return
             }
 
-            let effectiveScale = max(Int(sf), 1)
-            let columns = result.pixelWidth / (8 * effectiveScale)
-            let rows = result.pixelHeight / (16 * effectiveScale)
+            let (columns, rows) = result.gridSize(scaleFactor: Int(sf))
             let contentCols = Renderer.contentColumnsPerRow(for: result, columns: columns, rows: rows)
 
             DispatchQueue.main.async {

--- a/Sources/AnsiSaver/AnsiSaverView.swift
+++ b/Sources/AnsiSaver/AnsiSaverView.swift
@@ -98,7 +98,9 @@ class AnsiSaverView: ScreenSaverView {
             self.artPaths = allPaths.shuffled()
             Configuration.debugLog("loadArt: found \(allPaths.count) files, first: \(allPaths.first ?? "none")")
 
-            if self.config.continuousScroll {
+            if self.config.isModemMode {
+                self.startModemMode()
+            } else if self.config.continuousScroll {
                 self.startContinuousMode()
             } else {
                 self.showNextArt()
@@ -113,9 +115,23 @@ class AnsiSaverView: ScreenSaverView {
         let path = nextArtPath()
         let transition = TransitionMode(rawValue: config.transitionMode) ?? .scrollUp
 
+        let useModem = self.config.isModemMode
+
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
-            guard let image = Renderer.render(ansFileAt: path, scaleFactor: self.config.scaleFactor <= 1 ? 0 : UInt8(self.config.scaleFactor)) else {
+            let sf: UInt8 = self.config.scaleFactor <= 1 ? 0 : UInt8(self.config.scaleFactor)
+
+            let renderResult: RenderResult?
+            let image: NSImage?
+            if useModem {
+                renderResult = Renderer.renderWithInfo(ansFileAt: path, scaleFactor: sf)
+                image = renderResult?.image
+            } else {
+                renderResult = nil
+                image = Renderer.render(ansFileAt: path, scaleFactor: sf)
+            }
+
+            guard let image = image else {
                 DispatchQueue.main.async {
                     self.consecutiveFailures += 1
                     if self.consecutiveFailures < self.maxConsecutiveFailures {
@@ -127,9 +143,28 @@ class AnsiSaverView: ScreenSaverView {
                 return
             }
 
+            // For modem mode, compute content columns per row on background thread
+            let modemInfo: (columns: Int, rows: Int, contentCols: [Int])?
+            if useModem, let result = renderResult {
+                let effectiveScale = max(Int(sf), 1)
+                let columns = result.pixelWidth / (8 * effectiveScale)
+                let rows = result.pixelHeight / (16 * effectiveScale)
+                let contentCols = Renderer.contentColumnsPerRow(for: result, columns: columns, rows: rows)
+                modemInfo = (columns, rows, contentCols)
+            } else {
+                modemInfo = nil
+            }
+
             DispatchQueue.main.async {
                 self.consecutiveFailures = 0
-                if self.config.continuousScroll {
+                if useModem, let info = modemInfo {
+                    self.animator?.appendModemArt(
+                        image: image,
+                        columns: info.columns,
+                        rows: info.rows,
+                        contentColumnsPerRow: info.contentCols
+                    )
+                } else if self.config.continuousScroll {
                     let fileName = (path as NSString).lastPathComponent
                     self.animator?.appendArt(image: image, fileName: fileName, showSeparator: self.config.showSeparator)
                 } else {
@@ -173,6 +208,46 @@ class AnsiSaverView: ScreenSaverView {
                     speed: self.config.scrollSpeed,
                     viewSize: self.bounds.size,
                     showSeparator: self.config.showSeparator
+                )
+            }
+        }
+    }
+
+    private func startModemMode() {
+        guard !artPaths.isEmpty else { return }
+        guard bounds.size.width > 0, bounds.size.height > 0 else { return }
+
+        let path = nextArtPath()
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            let sf: UInt8 = self.config.scaleFactor <= 1 ? 0 : UInt8(self.config.scaleFactor)
+            guard let result = Renderer.renderWithInfo(ansFileAt: path, scaleFactor: sf) else {
+                DispatchQueue.main.async {
+                    self.consecutiveFailures += 1
+                    if self.consecutiveFailures < self.maxConsecutiveFailures {
+                        self.startModemMode()
+                    } else {
+                        self.showMessage("Unable to render art files.")
+                    }
+                }
+                return
+            }
+
+            let effectiveScale = max(Int(sf), 1)
+            let columns = result.pixelWidth / (8 * effectiveScale)
+            let rows = result.pixelHeight / (16 * effectiveScale)
+            let contentCols = Renderer.contentColumnsPerRow(for: result, columns: columns, rows: rows)
+
+            DispatchQueue.main.async {
+                self.consecutiveFailures = 0
+                self.animator?.startModemContinuous(
+                    firstImage: result.image,
+                    columns: columns,
+                    rows: rows,
+                    contentColumnsPerRow: contentCols,
+                    modemSpeed: self.config.modemSpeed,
+                    viewSize: self.bounds.size
                 )
             }
         }

--- a/Sources/AnsiSaver/AnsiSaverView.swift
+++ b/Sources/AnsiSaver/AnsiSaverView.swift
@@ -116,6 +116,9 @@ class AnsiSaverView: ScreenSaverView {
         let transition = TransitionMode(rawValue: config.transitionMode) ?? .scrollUp
 
         let useModem = self.config.isModemMode
+        if useModem {
+            animator?.nextFileName = (path as NSString).lastPathComponent
+        }
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
@@ -243,6 +246,7 @@ class AnsiSaverView: ScreenSaverView {
                     rows: rows,
                     contentColumnsPerRow: contentCols,
                     modemSpeed: self.config.modemSpeed,
+                    scaleFactor: sf,
                     viewSize: self.bounds.size
                 )
             }

--- a/Sources/AnsiSaver/ConfigSheet.swift
+++ b/Sources/AnsiSaver/ConfigSheet.swift
@@ -22,9 +22,6 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
     private var modernViews: [NSView] = []
     private var modemViews: [NSView] = []
 
-    private static let modemSpeeds = [300, 1200, 2400, 9600, 14400, 28800, 33600, 56000]
-    private static let modemLabels = ["300", "1200", "2400", "9600", "14.4k", "28.8k", "33.6k", "56k"]
-
     init(config: Configuration) {
         self.config = config
         self.packURLs = config.packURLs
@@ -45,7 +42,7 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         } else {
             folderPathControl.url = nil
         }
-        displayModePopup.selectItem(at: newConfig.displayMode)
+        displayModePopup.selectItem(at: newConfig.displayMode.rawValue)
         transitionPopup.selectItem(at: newConfig.transitionMode)
         speedSlider.doubleValue = newConfig.scrollSpeed
         speedValueLabel.stringValue = "\(Int(newConfig.scrollSpeed)) px/s"
@@ -53,7 +50,7 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         continuousCheck.state = newConfig.continuousScroll ? .on : .off
         separatorCheck.state = newConfig.showSeparator ? .on : .off
         separatorCheck.isEnabled = newConfig.continuousScroll
-        let modemIndex = Self.modemSpeeds.firstIndex(of: newConfig.modemSpeed) ?? 2
+        let modemIndex = ModemSpeed.allCases.firstIndex(of: newConfig.modemSpeed) ?? 2
         modemPopup.selectItem(at: modemIndex)
         updateDisplayMode()
     }
@@ -111,7 +108,7 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         y = addLabel("Display Mode:", to: contentView, y: y)
         displayModePopup = NSPopUpButton(frame: NSRect(x: 120, y: y + 2, width: 180, height: 24))
         displayModePopup.addItems(withTitles: ["Modern", "Modem"])
-        displayModePopup.selectItem(at: config.displayMode)
+        displayModePopup.selectItem(at: config.displayMode.rawValue)
         displayModePopup.target = self
         displayModePopup.action = #selector(displayModeChanged)
         contentView.addSubview(displayModePopup)
@@ -182,8 +179,8 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
             my -= 22
 
             modemPopup = NSPopUpButton(frame: NSRect(x: 120, y: my + 2, width: 180, height: 24))
-            modemPopup.addItems(withTitles: Self.modemLabels)
-            let modemIndex = Self.modemSpeeds.firstIndex(of: config.modemSpeed) ?? 2
+            modemPopup.addItems(withTitles: ModemSpeed.allCases.map { $0.label })
+            let modemIndex = ModemSpeed.allCases.firstIndex(of: config.modemSpeed) ?? 2
             modemPopup.selectItem(at: modemIndex)
             contentView.addSubview(modemPopup)
             modemViews.append(modemPopup)
@@ -321,7 +318,7 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
     }
 
     private func updateDisplayMode() {
-        let isModem = displayModePopup.indexOfSelectedItem == 1
+        let isModem = DisplayMode(rawValue: displayModePopup.indexOfSelectedItem) == .modem
         for view in modernViews { view.isHidden = isModem }
         for view in modemViews { view.isHidden = !isModem }
     }
@@ -342,8 +339,11 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         config.scaleFactor = scalePopup.indexOfSelectedItem + 1
         config.continuousScroll = continuousCheck.state == .on
         config.showSeparator = separatorCheck.state == .on
-        config.displayMode = displayModePopup.indexOfSelectedItem
-        config.modemSpeed = Self.modemSpeeds[modemPopup.indexOfSelectedItem]
+        config.displayMode = DisplayMode(rawValue: displayModePopup.indexOfSelectedItem) ?? .modern
+        let modemIdx = modemPopup.indexOfSelectedItem
+        config.modemSpeed = (modemIdx >= 0 && modemIdx < ModemSpeed.allCases.count)
+            ? ModemSpeed.allCases[modemIdx]
+            : .baud2400
         config.save()
 
         dismissSheet()

--- a/Sources/AnsiSaver/ConfigSheet.swift
+++ b/Sources/AnsiSaver/ConfigSheet.swift
@@ -10,12 +10,20 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
 
     private var packTable: NSTableView!
     private var folderPathControl: NSPathControl!
+    private var displayModePopup: NSPopUpButton!
     private var transitionPopup: NSPopUpButton!
     private var speedSlider: NSSlider!
-    private var speedLabel: NSTextField!
+    private var speedValueLabel: NSTextField!
     private var scalePopup: NSPopUpButton!
     private var continuousCheck: NSButton!
     private var separatorCheck: NSButton!
+    private var modemPopup: NSPopUpButton!
+
+    private var modernViews: [NSView] = []
+    private var modemViews: [NSView] = []
+
+    private static let modemSpeeds = [300, 1200, 2400, 9600, 14400, 28800, 33600, 56000]
+    private static let modemLabels = ["300", "1200", "2400", "9600", "14.4k", "28.8k", "33.6k", "56k"]
 
     init(config: Configuration) {
         self.config = config
@@ -37,18 +45,22 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         } else {
             folderPathControl.url = nil
         }
+        displayModePopup.selectItem(at: newConfig.displayMode)
         transitionPopup.selectItem(at: newConfig.transitionMode)
         speedSlider.doubleValue = newConfig.scrollSpeed
-        speedLabel.stringValue = "\(Int(newConfig.scrollSpeed)) px/s"
-        scalePopup.selectItem(at: newConfig.scaleFactor - 1)
+        speedValueLabel.stringValue = "\(Int(newConfig.scrollSpeed)) px/s"
+        scalePopup.selectItem(at: max(newConfig.scaleFactor - 1, 0))
         continuousCheck.state = newConfig.continuousScroll ? .on : .off
         separatorCheck.state = newConfig.showSeparator ? .on : .off
         separatorCheck.isEnabled = newConfig.continuousScroll
+        let modemIndex = Self.modemSpeeds.firstIndex(of: newConfig.modemSpeed) ?? 2
+        modemPopup.selectItem(at: modemIndex)
+        updateDisplayMode()
     }
 
     private func buildWindow() {
         window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 480),
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 520),
             styleMask: [.titled],
             backing: .buffered,
             defer: true
@@ -59,7 +71,10 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         contentView.autoresizingMask = [.width, .height]
         window.contentView = contentView
 
-        var y: CGFloat = 440
+        modernViews = []
+        modemViews = []
+
+        var y: CGFloat = 480
 
         // Pack URLs section
         y = addLabel("16colo.rs Pack URLs:", to: contentView, y: y)
@@ -84,50 +99,99 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         contentView.addSubview(browseButton)
         y -= 40
 
-        // Transition mode
-        y = addLabel("Transition:", to: contentView, y: y)
-        transitionPopup = NSPopUpButton(frame: NSRect(x: 120, y: y + 2, width: 180, height: 24))
-        transitionPopup.addItems(withTitles: ["Scroll Up", "Scroll Down", "Crossfade"])
-        transitionPopup.selectItem(at: config.transitionMode)
-        contentView.addSubview(transitionPopup)
-        y -= 14
-
-        // Speed slider
-        y = addLabel("Scroll Speed:", to: contentView, y: y)
-        speedSlider = NSSlider(frame: NSRect(x: 120, y: y + 4, width: 280, height: 20))
-        speedSlider.minValue = 10
-        speedSlider.maxValue = 200
-        speedSlider.doubleValue = config.scrollSpeed
-        speedSlider.target = self
-        speedSlider.action = #selector(speedChanged)
-        contentView.addSubview(speedSlider)
-
-        speedLabel = NSTextField(labelWithString: "\(Int(config.scrollSpeed)) px/s")
-        speedLabel.frame = NSRect(x: 410, y: y + 2, width: 80, height: 20)
-        contentView.addSubview(speedLabel)
-        y -= 20
-
-        // Scale factor
+        // Render scale (applies to both modes)
         y = addLabel("Render Scale:", to: contentView, y: y)
         scalePopup = NSPopUpButton(frame: NSRect(x: 120, y: y + 2, width: 180, height: 24))
         scalePopup.addItems(withTitles: ["1x", "2x", "3x", "4x"])
-        scalePopup.selectItem(at: config.scaleFactor - 1)
+        scalePopup.selectItem(at: max(config.scaleFactor - 1, 0))
         contentView.addSubview(scalePopup)
         y -= 14
 
-        // Continuous scroll
-        continuousCheck = NSButton(checkboxWithTitle: "Continuous scroll", target: self, action: #selector(continuousChanged))
-        continuousCheck.frame = NSRect(x: 20, y: y - 20, width: 200, height: 18)
-        continuousCheck.state = config.continuousScroll ? .on : .off
-        contentView.addSubview(continuousCheck)
-        y -= 24
+        // Display mode toggle
+        y = addLabel("Display Mode:", to: contentView, y: y)
+        displayModePopup = NSPopUpButton(frame: NSRect(x: 120, y: y + 2, width: 180, height: 24))
+        displayModePopup.addItems(withTitles: ["Modern", "Modem"])
+        displayModePopup.selectItem(at: config.displayMode)
+        displayModePopup.target = self
+        displayModePopup.action = #selector(displayModeChanged)
+        contentView.addSubview(displayModePopup)
+        y -= 14
 
-        separatorCheck = NSButton(checkboxWithTitle: "Show separator between files", target: nil, action: nil)
-        separatorCheck.frame = NSRect(x: 40, y: y - 20, width: 240, height: 18)
-        separatorCheck.state = config.showSeparator ? .on : .off
-        separatorCheck.isEnabled = config.continuousScroll
-        contentView.addSubview(separatorCheck)
-        y -= 28
+        // ---- Mode-specific controls occupy the same vertical region ----
+        let modeStartY = y
+
+        // Modern controls
+        do {
+            var my = modeStartY
+
+            let transLabel = makeFieldLabel("Transition:", at: my, in: contentView)
+            modernViews.append(transLabel)
+            my -= 22
+
+            transitionPopup = NSPopUpButton(frame: NSRect(x: 120, y: my + 2, width: 180, height: 24))
+            transitionPopup.addItems(withTitles: ["Scroll Up", "Scroll Down", "Crossfade"])
+            transitionPopup.selectItem(at: config.transitionMode)
+            contentView.addSubview(transitionPopup)
+            modernViews.append(transitionPopup)
+            my -= 14
+
+            let speedLabel = makeFieldLabel("Scroll Speed:", at: my, in: contentView)
+            modernViews.append(speedLabel)
+            my -= 22
+
+            speedSlider = NSSlider(frame: NSRect(x: 120, y: my + 4, width: 280, height: 20))
+            speedSlider.minValue = 10
+            speedSlider.maxValue = 200
+            speedSlider.doubleValue = config.scrollSpeed
+            speedSlider.target = self
+            speedSlider.action = #selector(speedChanged)
+            contentView.addSubview(speedSlider)
+            modernViews.append(speedSlider)
+
+            speedValueLabel = NSTextField(labelWithString: "\(Int(config.scrollSpeed)) px/s")
+            speedValueLabel.frame = NSRect(x: 410, y: my + 2, width: 80, height: 20)
+            contentView.addSubview(speedValueLabel)
+            modernViews.append(speedValueLabel)
+            my -= 20
+
+            continuousCheck = NSButton(checkboxWithTitle: "Continuous scroll", target: self, action: #selector(continuousChanged))
+            continuousCheck.frame = NSRect(x: 20, y: my - 20, width: 200, height: 18)
+            continuousCheck.state = config.continuousScroll ? .on : .off
+            contentView.addSubview(continuousCheck)
+            modernViews.append(continuousCheck)
+            my -= 24
+
+            separatorCheck = NSButton(checkboxWithTitle: "Show separator between files", target: nil, action: nil)
+            separatorCheck.frame = NSRect(x: 40, y: my - 20, width: 240, height: 18)
+            separatorCheck.state = config.showSeparator ? .on : .off
+            separatorCheck.isEnabled = config.continuousScroll
+            contentView.addSubview(separatorCheck)
+            modernViews.append(separatorCheck)
+            my -= 28
+
+            // Use the bottom of the modern section as the continuation point
+            y = my
+        }
+
+        // Modem controls (placed at same start position)
+        do {
+            var my = modeStartY
+
+            let baudLabel = makeFieldLabel("Baud Rate:", at: my, in: contentView)
+            modemViews.append(baudLabel)
+            my -= 22
+
+            modemPopup = NSPopUpButton(frame: NSRect(x: 120, y: my + 2, width: 180, height: 24))
+            modemPopup.addItems(withTitles: Self.modemLabels)
+            let modemIndex = Self.modemSpeeds.firstIndex(of: config.modemSpeed) ?? 2
+            modemPopup.selectItem(at: modemIndex)
+            contentView.addSubview(modemPopup)
+            modemViews.append(modemPopup)
+        }
+
+        updateDisplayMode()
+
+        // ---- End mode-specific region ----
 
         // Refetch button
         let refetchButton = NSButton(title: "Refetch Packs", target: self, action: #selector(refetchPacks))
@@ -144,6 +208,14 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         cancelButton.frame = NSRect(x: 310, y: 10, width: 90, height: 28)
         cancelButton.keyEquivalent = "\u{1b}"
         contentView.addSubview(cancelButton)
+    }
+
+    private func makeFieldLabel(_ text: String, at y: CGFloat, in view: NSView) -> NSTextField {
+        let label = NSTextField(labelWithString: text)
+        label.font = .boldSystemFont(ofSize: 12)
+        label.frame = NSRect(x: 20, y: y - 18, width: 100, height: 18)
+        view.addSubview(label)
+        return label
     }
 
     @discardableResult
@@ -237,11 +309,21 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
     }
 
     @objc private func speedChanged() {
-        speedLabel.stringValue = "\(Int(speedSlider.doubleValue)) px/s"
+        speedValueLabel.stringValue = "\(Int(speedSlider.doubleValue)) px/s"
     }
 
     @objc private func continuousChanged() {
         separatorCheck.isEnabled = continuousCheck.state == .on
+    }
+
+    @objc private func displayModeChanged() {
+        updateDisplayMode()
+    }
+
+    private func updateDisplayMode() {
+        let isModem = displayModePopup.indexOfSelectedItem == 1
+        for view in modernViews { view.isHidden = isModem }
+        for view in modemViews { view.isHidden = !isModem }
     }
 
     @objc private func refetchPacks() {
@@ -260,6 +342,8 @@ class ConfigSheet: NSObject, NSTableViewDataSource, NSTableViewDelegate {
         config.scaleFactor = scalePopup.indexOfSelectedItem + 1
         config.continuousScroll = continuousCheck.state == .on
         config.showSeparator = separatorCheck.state == .on
+        config.displayMode = displayModePopup.indexOfSelectedItem
+        config.modemSpeed = Self.modemSpeeds[modemPopup.indexOfSelectedItem]
         config.save()
 
         dismissSheet()

--- a/Sources/AnsiSaver/Configuration.swift
+++ b/Sources/AnsiSaver/Configuration.swift
@@ -14,6 +14,8 @@ struct Configuration {
         static let scaleFactor = "scaleFactor"
         static let continuousScroll = "continuousScroll"
         static let showSeparator = "showSeparator"
+        static let displayMode = "displayMode"
+        static let modemSpeed = "modemSpeed"
     }
 
     var packURLs: [String]
@@ -24,6 +26,10 @@ struct Configuration {
     var scaleFactor: Int
     var continuousScroll: Bool
     var showSeparator: Bool
+    var displayMode: Int
+    var modemSpeed: Int
+
+    var isModemMode: Bool { displayMode == 1 }
 
     var localFolderPath: String? {
         guard let bookmark = localFolderBookmark else { return nil }
@@ -53,7 +59,11 @@ struct Configuration {
             continuousScroll: defaults.bool(forKey: Key.continuousScroll),
             showSeparator: defaults.object(forKey: Key.showSeparator) != nil
                 ? defaults.bool(forKey: Key.showSeparator)
-                : true
+                : true,
+            displayMode: defaults.integer(forKey: Key.displayMode),
+            modemSpeed: defaults.object(forKey: Key.modemSpeed) != nil
+                ? defaults.integer(forKey: Key.modemSpeed)
+                : 2400
         )
         Self.debugLog("Config.load() process=\(ProcessInfo.processInfo.processName) bookmark=\(config.localFolderBookmark?.count ?? 0) bytes, packs=\(config.packURLs.count), files=\(config.fileURLs.count), folderPath=\(config.localFolderPath ?? "nil")")
         return config
@@ -69,6 +79,8 @@ struct Configuration {
         defaults.set(scaleFactor, forKey: Key.scaleFactor)
         defaults.set(continuousScroll, forKey: Key.continuousScroll)
         defaults.set(showSeparator, forKey: Key.showSeparator)
+        defaults.set(displayMode, forKey: Key.displayMode)
+        defaults.set(modemSpeed, forKey: Key.modemSpeed)
         let ok = defaults.synchronize()
         Self.debugLog("Config.save() process=\(ProcessInfo.processInfo.processName) sync=\(ok) bookmark=\(localFolderBookmark?.count ?? 0) bytes, packs=\(packURLs.count)")
     }

--- a/Sources/AnsiSaver/Configuration.swift
+++ b/Sources/AnsiSaver/Configuration.swift
@@ -1,6 +1,40 @@
 import Foundation
 import ScreenSaver
 
+enum DisplayMode: Int {
+    case modern = 0
+    case modem = 1
+}
+
+enum ModemSpeed: Int, CaseIterable {
+    case baud300 = 300
+    case baud1200 = 1200
+    case baud2400 = 2400
+    case baud9600 = 9600
+    case baud14400 = 14400
+    case baud28800 = 28800
+    case baud33600 = 33600
+    case baud56000 = 56000
+
+    var label: String {
+        switch self {
+        case .baud300: return "300"
+        case .baud1200: return "1200"
+        case .baud2400: return "2400"
+        case .baud9600: return "9600"
+        case .baud14400: return "14.4k"
+        case .baud28800: return "28.8k"
+        case .baud33600: return "33.6k"
+        case .baud56000: return "56k"
+        }
+    }
+
+    /// Characters per animation frame at 60fps, assuming 8N1 encoding (10 bits/char).
+    var charsPerFrame: CGFloat {
+        CGFloat(rawValue) / 10.0 / 60.0
+    }
+}
+
 struct Configuration {
 
     private static let moduleName = "com.lardissone.AnsiSaver"
@@ -26,10 +60,10 @@ struct Configuration {
     var scaleFactor: Int
     var continuousScroll: Bool
     var showSeparator: Bool
-    var displayMode: Int
-    var modemSpeed: Int
+    var displayMode: DisplayMode
+    var modemSpeed: ModemSpeed
 
-    var isModemMode: Bool { displayMode == 1 }
+    var isModemMode: Bool { displayMode == .modem }
 
     var localFolderPath: String? {
         guard let bookmark = localFolderBookmark else { return nil }
@@ -60,10 +94,10 @@ struct Configuration {
             showSeparator: defaults.object(forKey: Key.showSeparator) != nil
                 ? defaults.bool(forKey: Key.showSeparator)
                 : true,
-            displayMode: defaults.integer(forKey: Key.displayMode),
-            modemSpeed: defaults.object(forKey: Key.modemSpeed) != nil
+            displayMode: DisplayMode(rawValue: defaults.integer(forKey: Key.displayMode)) ?? .modern,
+            modemSpeed: ModemSpeed(rawValue: defaults.object(forKey: Key.modemSpeed) != nil
                 ? defaults.integer(forKey: Key.modemSpeed)
-                : 2400
+                : 2400) ?? .baud2400
         )
         Self.debugLog("Config.load() process=\(ProcessInfo.processInfo.processName) bookmark=\(config.localFolderBookmark?.count ?? 0) bytes, packs=\(config.packURLs.count), files=\(config.fileURLs.count), folderPath=\(config.localFolderPath ?? "nil")")
         return config
@@ -79,8 +113,8 @@ struct Configuration {
         defaults.set(scaleFactor, forKey: Key.scaleFactor)
         defaults.set(continuousScroll, forKey: Key.continuousScroll)
         defaults.set(showSeparator, forKey: Key.showSeparator)
-        defaults.set(displayMode, forKey: Key.displayMode)
-        defaults.set(modemSpeed, forKey: Key.modemSpeed)
+        defaults.set(displayMode.rawValue, forKey: Key.displayMode)
+        defaults.set(modemSpeed.rawValue, forKey: Key.modemSpeed)
         let ok = defaults.synchronize()
         Self.debugLog("Config.save() process=\(ProcessInfo.processInfo.processName) sync=\(ok) bookmark=\(localFolderBookmark?.count ?? 0) bytes, packs=\(packURLs.count)")
     }

--- a/Sources/AnsiSaver/Renderer.swift
+++ b/Sources/AnsiSaver/Renderer.swift
@@ -4,6 +4,15 @@ struct RenderResult {
     let image: NSImage
     let pixelWidth: Int
     let pixelHeight: Int
+
+    /// Grid dimensions for the given scale factor.
+    func gridSize(scaleFactor: Int) -> (columns: Int, rows: Int) {
+        let effective = max(scaleFactor, 1)
+        return (
+            columns: max(pixelWidth / (8 * effective), 1),
+            rows: max(pixelHeight / (16 * effective), 1)
+        )
+    }
 }
 
 enum Renderer {
@@ -46,11 +55,12 @@ enum Renderer {
     }
 
     /// Scan the rendered image to find content width (in character columns) per row.
-    /// A character cell is considered empty if all its pixels are black (RGB < 3).
+    /// A character cell is considered empty if each of its R, G, B channels is <= 2.
     /// This allows modem simulation to skip trailing blank columns per row.
     static func contentColumnsPerRow(for result: RenderResult, columns: Int, rows: Int) -> [Int] {
         guard columns > 0, rows > 0 else { return [] }
         guard let cgImage = result.image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            Configuration.debugLog("contentColumnsPerRow: failed to get cgImage")
             return Array(repeating: columns, count: rows)
         }
 
@@ -71,6 +81,7 @@ enum Renderer {
             space: colorSpace,
             bitmapInfo: bitmapInfo
         ) else {
+            Configuration.debugLog("contentColumnsPerRow: CGContext creation failed (width=\(width), height=\(height))")
             return Array(repeating: columns, count: rows)
         }
 

--- a/Sources/AnsiSaver/Renderer.swift
+++ b/Sources/AnsiSaver/Renderer.swift
@@ -1,8 +1,18 @@
 import AppKit
 
+struct RenderResult {
+    let image: NSImage
+    let pixelWidth: Int
+    let pixelHeight: Int
+}
+
 enum Renderer {
 
     static func render(ansFileAt path: String, scaleFactor: UInt8 = 0) -> NSImage? {
+        return renderWithInfo(ansFileAt: path, scaleFactor: scaleFactor)?.image
+    }
+
+    static func renderWithInfo(ansFileAt path: String, scaleFactor: UInt8 = 0) -> RenderResult? {
         var ctx = ansilove_ctx()
         var options = ansilove_options()
 
@@ -19,6 +29,86 @@ enum Renderer {
         guard ctx.png.buffer != nil, ctx.png.length > 0 else { return nil }
 
         let data = Data(bytes: ctx.png.buffer, count: Int(ctx.png.length))
-        return NSImage(data: data)
+        guard let image = NSImage(data: data) else { return nil }
+
+        // Get actual pixel dimensions from the bitmap representation
+        let pixelWidth: Int
+        let pixelHeight: Int
+        if let rep = image.representations.first {
+            pixelWidth = rep.pixelsWide
+            pixelHeight = rep.pixelsHigh
+        } else {
+            pixelWidth = Int(image.size.width)
+            pixelHeight = Int(image.size.height)
+        }
+
+        return RenderResult(image: image, pixelWidth: pixelWidth, pixelHeight: pixelHeight)
+    }
+
+    /// Scan the rendered image to find content width (in character columns) per row.
+    /// A character cell is considered empty if all its pixels are black (RGB < 3).
+    /// This allows modem simulation to skip trailing blank columns per row.
+    static func contentColumnsPerRow(for result: RenderResult, columns: Int, rows: Int) -> [Int] {
+        guard columns > 0, rows > 0 else { return [] }
+        guard let cgImage = result.image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return Array(repeating: columns, count: rows)
+        }
+
+        let width = result.pixelWidth
+        let height = result.pixelHeight
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let ctx = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return Array(repeating: columns, count: rows)
+        }
+
+        // Flip to top-down so row 0 in memory = top of image
+        ctx.translateBy(x: 0, y: CGFloat(height))
+        ctx.scaleBy(x: 1, y: -1)
+        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let charWidth = width / columns
+        let charHeight = height / rows
+        var contentCols = [Int](repeating: 0, count: rows)
+
+        for row in 0..<rows {
+            let cellY = row * charHeight
+            let cellYEnd = min(cellY + charHeight, height)
+            // Scan columns right-to-left; stop at first non-black cell
+            for col in stride(from: columns - 1, through: 0, by: -1) {
+                let cellX = col * charWidth
+                let cellXEnd = min(cellX + charWidth, width)
+                var empty = true
+                for py in cellY..<cellYEnd {
+                    let rowOffset = py * bytesPerRow
+                    for px in cellX..<cellXEnd {
+                        let offset = rowOffset + px * bytesPerPixel
+                        if pixels[offset] > 2 || pixels[offset + 1] > 2 || pixels[offset + 2] > 2 {
+                            empty = false
+                            break
+                        }
+                    }
+                    if !empty { break }
+                }
+                if !empty {
+                    contentCols[row] = col + 1
+                    break
+                }
+            }
+        }
+
+        return contentCols
     }
 }

--- a/Sources/AnsiSaver/Renderer.swift
+++ b/Sources/AnsiSaver/Renderer.swift
@@ -54,6 +54,49 @@ enum Renderer {
         return RenderResult(image: image, pixelWidth: pixelWidth, pixelHeight: pixelHeight)
     }
 
+    /// Render a Z-Modem transfer status line using ansilove with DOS colors
+    /// and a CP437 shade gradient prefix in a random bright color.
+    /// Returns the image and the cursor column (character position after the text).
+    static func renderLoadingMessage(fileName: String, scaleFactor: UInt8 = 0) -> (image: NSImage, cursorColumn: Int)? {
+        let displayName = String(fileName.prefix(40))
+
+        // Random bright color for the shade gradient (31-36 = R,G,Y,B,M,C)
+        let colorCode = Int.random(in: 31...36)
+
+        // Build raw bytes — CP437 shade characters (0xB0-0xB2, 0xDB) must be
+        // written as literal byte values since they differ from ISO-8859-1.
+        var bytes = Data()
+        // ░▒▓█ in random bright color
+        bytes.append(contentsOf: "\u{1b}[1;\(colorCode)m".utf8)
+        bytes.append(contentsOf: [0xB0, 0xB1, 0xB2, 0xDB] as [UInt8])
+        // Dark grey text
+        bytes.append(contentsOf: "\u{1b}[1;30m".utf8)
+        bytes.append(contentsOf: " Initiating Z-Modem transfer of ".utf8)
+        // Normal grey filename
+        bytes.append(contentsOf: "\u{1b}[0;37m".utf8)
+        bytes.append(contentsOf: displayName.utf8)
+        // Dark grey "..."
+        bytes.append(contentsOf: "\u{1b}[1;30m".utf8)
+        bytes.append(contentsOf: "...".utf8)
+        // Reset
+        bytes.append(contentsOf: "\u{1b}[0m".utf8)
+
+        // 4 shade + " Initiating Z-Modem transfer of " (32) + name + "..." (3)
+        let cursorColumn = 39 + displayName.count
+
+        let tempPath = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("ansisaver-loading.ans")
+        do {
+            try bytes.write(to: URL(fileURLWithPath: tempPath))
+        } catch {
+            return nil
+        }
+        defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+        guard let image = render(ansFileAt: tempPath, scaleFactor: scaleFactor) else { return nil }
+        return (image, cursorColumn)
+    }
+
     /// Scan the rendered image to find content width (in character columns) per row.
     /// A character cell is considered empty if each of its R, G, B channels is <= 2.
     /// This allows modem simulation to skip trailing blank columns per row.

--- a/Tests/AnsiSaverTests/ConfigurationTests.swift
+++ b/Tests/AnsiSaverTests/ConfigurationTests.swift
@@ -13,6 +13,8 @@ final class ConfigurationTests: XCTestCase {
         defaults.removeObject(forKey: "scaleFactor")
         defaults.removeObject(forKey: "continuousScroll")
         defaults.removeObject(forKey: "showSeparator")
+        defaults.removeObject(forKey: "displayMode")
+        defaults.removeObject(forKey: "modemSpeed")
         defaults.synchronize()
         super.tearDown()
     }
@@ -28,6 +30,9 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.scaleFactor, 2)
         XCTAssertFalse(config.continuousScroll)
         XCTAssertTrue(config.showSeparator)
+        XCTAssertEqual(config.displayMode, 0)
+        XCTAssertEqual(config.modemSpeed, 2400)
+        XCTAssertFalse(config.isModemMode)
     }
 
     func testSaveAndLoadURLs() {
@@ -43,6 +48,18 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(loaded.fileURLs, ["https://example.com/art.ans"])
         XCTAssertEqual(loaded.transitionMode, 2)
         XCTAssertEqual(loaded.scrollSpeed, 100.0)
+    }
+
+    func testSaveAndLoadModemSettings() {
+        var config = Configuration.load()
+        config.displayMode = 1
+        config.modemSpeed = 9600
+        config.save()
+
+        let loaded = Configuration.load()
+        XCTAssertEqual(loaded.displayMode, 1)
+        XCTAssertEqual(loaded.modemSpeed, 9600)
+        XCTAssertTrue(loaded.isModemMode)
     }
 
     func testBookmarkCreation() {

--- a/Tests/AnsiSaverTests/ConfigurationTests.swift
+++ b/Tests/AnsiSaverTests/ConfigurationTests.swift
@@ -30,8 +30,8 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.scaleFactor, 2)
         XCTAssertFalse(config.continuousScroll)
         XCTAssertTrue(config.showSeparator)
-        XCTAssertEqual(config.displayMode, 0)
-        XCTAssertEqual(config.modemSpeed, 2400)
+        XCTAssertEqual(config.displayMode, .modern)
+        XCTAssertEqual(config.modemSpeed, .baud2400)
         XCTAssertFalse(config.isModemMode)
     }
 
@@ -52,14 +52,32 @@ final class ConfigurationTests: XCTestCase {
 
     func testSaveAndLoadModemSettings() {
         var config = Configuration.load()
-        config.displayMode = 1
-        config.modemSpeed = 9600
+        config.displayMode = .modem
+        config.modemSpeed = .baud9600
         config.save()
 
         let loaded = Configuration.load()
-        XCTAssertEqual(loaded.displayMode, 1)
-        XCTAssertEqual(loaded.modemSpeed, 9600)
+        XCTAssertEqual(loaded.displayMode, .modem)
+        XCTAssertEqual(loaded.modemSpeed, .baud9600)
         XCTAssertTrue(loaded.isModemMode)
+    }
+
+    func testCorruptedModemSpeedFallsBackToDefault() {
+        let defaults = ScreenSaverDefaults(forModuleWithName: "com.lardissone.AnsiSaver")!
+        defaults.set(0, forKey: "modemSpeed")
+        defaults.synchronize()
+
+        let config = Configuration.load()
+        XCTAssertEqual(config.modemSpeed, .baud2400)
+    }
+
+    func testCorruptedDisplayModeFallsBackToDefault() {
+        let defaults = ScreenSaverDefaults(forModuleWithName: "com.lardissone.AnsiSaver")!
+        defaults.set(99, forKey: "displayMode")
+        defaults.synchronize()
+
+        let config = Configuration.load()
+        XCTAssertEqual(config.displayMode, .modern)
     }
 
     func testBookmarkCreation() {

--- a/Tests/AnsiSaverTests/RendererTests.swift
+++ b/Tests/AnsiSaverTests/RendererTests.swift
@@ -12,6 +12,31 @@ final class RendererTests: XCTestCase {
         XCTAssertGreaterThan(image.size.height, 0)
     }
 
+    func testRenderWithInfoProducesPixelDimensions() throws {
+        let fixturePath = fixturesPath().appendingPathComponent("sample.ans").path
+        let result = try XCTUnwrap(Renderer.renderWithInfo(ansFileAt: fixturePath))
+        XCTAssertGreaterThan(result.pixelWidth, 0)
+        XCTAssertGreaterThan(result.pixelHeight, 0)
+        // CP437 at 8px wide, default 80 columns: width should be multiple of 8
+        XCTAssertEqual(result.pixelWidth % 8, 0)
+        // CP437 at 16px tall: height should be multiple of 16
+        XCTAssertEqual(result.pixelHeight % 16, 0)
+    }
+
+    func testContentColumnsPerRow() throws {
+        let fixturePath = fixturesPath().appendingPathComponent("sample.ans").path
+        let result = try XCTUnwrap(Renderer.renderWithInfo(ansFileAt: fixturePath))
+        let columns = result.pixelWidth / 8
+        let rows = result.pixelHeight / 16
+        let contentCols = Renderer.contentColumnsPerRow(for: result, columns: columns, rows: rows)
+        XCTAssertEqual(contentCols.count, rows)
+        // Every entry should be between 0 and columns
+        for cols in contentCols {
+            XCTAssertGreaterThanOrEqual(cols, 0)
+            XCTAssertLessThanOrEqual(cols, columns)
+        }
+    }
+
     func testRenderReturnsNilForMissingFile() {
         let image = Renderer.render(ansFileAt: "/nonexistent/path/file.ans")
         XCTAssertNil(image)

--- a/Tests/AnsiSaverTests/RendererTests.swift
+++ b/Tests/AnsiSaverTests/RendererTests.swift
@@ -35,6 +35,21 @@ final class RendererTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(cols, 0)
             XCTAssertLessThanOrEqual(cols, columns)
         }
+        // First row of sample.ans should have visible content
+        XCTAssertGreaterThan(contentCols[0], 0, "First row should have visible content")
+        // At least some rows should have trailing empty columns
+        let hasTrailingBlanks = contentCols.contains(where: { $0 < columns })
+        XCTAssertTrue(hasTrailingBlanks, "At least some rows should have trailing empty columns")
+    }
+
+    func testGridSize() throws {
+        let fixturePath = fixturesPath().appendingPathComponent("sample.ans").path
+        let result = try XCTUnwrap(Renderer.renderWithInfo(ansFileAt: fixturePath))
+        let (columns, rows) = result.gridSize(scaleFactor: 1)
+        XCTAssertGreaterThan(columns, 0)
+        XCTAssertGreaterThan(rows, 0)
+        XCTAssertEqual(columns, result.pixelWidth / 8)
+        XCTAssertEqual(rows, result.pixelHeight / 16)
     }
 
     func testRenderReturnsNilForMissingFile() {


### PR DESCRIPTION
This screen saver is so cool! It immediately made me think of my younger days connecting to BBSs with my modem, and I thought it would be neat to have a mode that emulated that experience. My first modem was 300 baud, so we have the entire range. 2400 baud is probably a sweet spot for the experience.

<a href="https://youtu.be/cwgoDvFB8Ak">▶ Watch the modem simulation (2400 baud) demo video</a>

<img width="541" height="543" alt="image" src="https://github.com/user-attachments/assets/73004c62-1f79-49ec-b5f0-b10683add091" />

The new Display Mode setting has "Modern" (original), and then "Modem". Modern mode preserves all of the original settings that are relevant to that.

<img width="531" height="535" alt="image" src="https://github.com/user-attachments/assets/2d0a6f25-8729-4335-8fea-ab070c3c8ae4" />
