### PR TITLE
Filter plain text / NFO from art sources (ANSI content validation)

### DIFF
--- a/AnsiSaver.xcodeproj/project.pbxproj
+++ b/AnsiSaver.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A1000006 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000006 /* Animator.swift */; };
 		A1000007 /* PackFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000007 /* PackFetcher.swift */; };
 		A1000008 /* ConfigSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000008 /* ConfigSheet.swift */; };
+		A1000009 /* AnsiContentValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000009 /* AnsiContentValidator.swift */; };
 		A1000101 /* clean.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000101 /* clean.c */; };
 		A1000102 /* drawchar.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000102 /* drawchar.c */; };
 		A1000103 /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000103 /* error.c */; };
@@ -35,6 +36,7 @@
 		B1000002 /* PackFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000002 /* PackFetcherTests.swift */; };
 		B1000003 /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000003 /* CacheTests.swift */; };
 		B1000004 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000004 /* ConfigurationTests.swift */; };
+		B1000005 /* AnsiContentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000006 /* AnsiContentValidatorTests.swift */; };
 		B1100001 /* AnsiSaverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001 /* AnsiSaverView.swift */; };
 		B1100002 /* Renderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* Renderer.swift */; };
 		B1100003 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000003 /* Configuration.swift */; };
@@ -43,6 +45,7 @@
 		B1100006 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000006 /* Animator.swift */; };
 		B1100007 /* PackFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000007 /* PackFetcher.swift */; };
 		B1100008 /* ConfigSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000008 /* ConfigSheet.swift */; };
+		B1100009 /* AnsiContentValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000009 /* AnsiContentValidator.swift */; };
 		B1100101 /* clean.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000101 /* clean.c */; };
 		B1100102 /* drawchar.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000102 /* drawchar.c */; };
 		B1100103 /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = A2000103 /* error.c */; };
@@ -70,6 +73,7 @@
 		A2000006 /* Animator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animator.swift; sourceTree = "<group>"; };
 		A2000007 /* PackFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackFetcher.swift; sourceTree = "<group>"; };
 		A2000008 /* ConfigSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigSheet.swift; sourceTree = "<group>"; };
+		A2000009 /* AnsiContentValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiContentValidator.swift; sourceTree = "<group>"; };
 		A2000010 /* AnsiSaver.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AnsiSaver.saver; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2000011 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A2000012 /* AnsiSaver-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AnsiSaver-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -101,6 +105,7 @@
 		B2000002 /* PackFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackFetcherTests.swift; sourceTree = "<group>"; };
 		B2000003 /* CacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
 		B2000004 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		B2000006 /* AnsiContentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnsiContentValidatorTests.swift; sourceTree = "<group>"; };
 		B2000005 /* sample.ans */ = {isa = PBXFileReference; lastKnownFileType = file; path = sample.ans; sourceTree = "<group>"; };
 		B2000010 /* AnsiSaverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AnsiSaverTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -154,6 +159,7 @@
 				A2000006 /* Animator.swift */,
 				A2000007 /* PackFetcher.swift */,
 				A2000008 /* ConfigSheet.swift */,
+				A2000009 /* AnsiContentValidator.swift */,
 			);
 			path = AnsiSaver;
 			sourceTree = "<group>";
@@ -173,6 +179,7 @@
 				B2000002 /* PackFetcherTests.swift */,
 				B2000003 /* CacheTests.swift */,
 				B2000004 /* ConfigurationTests.swift */,
+				B2000006 /* AnsiContentValidatorTests.swift */,
 				B4000003 /* Fixtures */,
 			);
 			path = AnsiSaverTests;
@@ -353,6 +360,7 @@
 				A1000006 /* Animator.swift in Sources */,
 				A1000007 /* PackFetcher.swift in Sources */,
 				A1000008 /* ConfigSheet.swift in Sources */,
+				A1000009 /* AnsiContentValidator.swift in Sources */,
 				A1000101 /* clean.c in Sources */,
 				A1000102 /* drawchar.c in Sources */,
 				A1000103 /* error.c in Sources */,
@@ -380,6 +388,7 @@
 				B1000002 /* PackFetcherTests.swift in Sources */,
 				B1000003 /* CacheTests.swift in Sources */,
 				B1000004 /* ConfigurationTests.swift in Sources */,
+				B1000005 /* AnsiContentValidatorTests.swift in Sources */,
 				B1100001 /* AnsiSaverView.swift in Sources */,
 				B1100002 /* Renderer.swift in Sources */,
 				B1100003 /* Configuration.swift in Sources */,
@@ -388,6 +397,7 @@
 				B1100006 /* Animator.swift in Sources */,
 				B1100007 /* PackFetcher.swift in Sources */,
 				B1100008 /* ConfigSheet.swift in Sources */,
+				B1100009 /* AnsiContentValidator.swift in Sources */,
 				B1100101 /* clean.c in Sources */,
 				B1100102 /* drawchar.c in Sources */,
 				B1100103 /* error.c in Sources */,

--- a/AnsiSaver.xcodeproj/xcshareddata/xcschemes/AnsiSaver.xcscheme
+++ b/AnsiSaver.xcodeproj/xcshareddata/xcschemes/AnsiSaver.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5000001"
+               BuildableName = "AnsiSaver.saver"
+               BlueprintName = "AnsiSaver"
+               ReferencedContainer = "container:AnsiSaver.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5000001"
+               BuildableName = "AnsiSaverTests.xctest"
+               BlueprintName = "AnsiSaverTests"
+               ReferencedContainer = "container:AnsiSaver.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5000001"
+               BuildableName = "AnsiSaverTests.xctest"
+               BlueprintName = "AnsiSaverTests"
+               ReferencedContainer = "container:AnsiSaver.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5000001"
+            BuildableName = "AnsiSaver.saver"
+            BlueprintName = "AnsiSaver"
+            ReferencedContainer = "container:AnsiSaver.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5000001"
+            BuildableName = "AnsiSaver.saver"
+            BlueprintName = "AnsiSaver"
+            ReferencedContainer = "container:AnsiSaver.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/AnsiSaver/AnsiContentValidator.swift
+++ b/Sources/AnsiSaver/AnsiContentValidator.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Rejects plain documentation text (.txt / .NFO style) while keeping ANSI, CP437 art,
+/// and binary formats (ICE, XBin, PCB, etc.) that libansilove renders.
+enum AnsiContentValidator {
+
+    /// Returns whether the bytes are likely scene ANSI/CP437 art or a supported binary format,
+    /// as opposed to plain text readme / NFO prose.
+    static func isLikelyAnsiArt(data: Data, fileName: String) -> Bool {
+        guard !data.isEmpty else { return false }
+
+        let ext = (fileName as NSString).pathExtension.lowercased()
+
+        // Binary and container formats — libansilove selects loaders from content; do not filter here.
+        if ["ice", "bin", "xb", "pcb", "adf"].contains(ext) {
+            return true
+        }
+
+        if hasAnsiEscapeOrCP437Art(data) {
+            return true
+        }
+
+        // Typical readme / info docs without escape codes or CP437 block characters.
+        if ["txt", "nfo"].contains(ext) {
+            return false
+        }
+
+        if looksLikePlainTextProse(data) {
+            return false
+        }
+
+        return true
+    }
+
+    /// ESC sequences or a meaningful amount of CP437 (high-bit) bytes.
+    static func hasAnsiEscapeOrCP437Art(_ data: Data) -> Bool {
+        let sample = data.prefix(512 * 1024)
+        if sample.isEmpty { return false }
+
+        if sample.contains(0x1B) {
+            return true
+        }
+
+        let highCount = sample.reduce(0) { $0 + ($1 >= 0x80 ? 1 : 0) }
+        return Double(highCount) / Double(sample.count) >= 0.004
+    }
+
+    /// Heuristic for README-style prose mislabeled as `.ans` / `.asc` (e.g. cached URL saved as `.ans`).
+    static func looksLikePlainTextProse(_ data: Data) -> Bool {
+        let sample = data.prefix(65_536)
+        if sample.contains(0x1B) { return false }
+
+        let highCount = sample.reduce(0) { $0 + ($1 >= 0x80 ? 1 : 0) }
+        if sample.count > 0, Double(highCount) / Double(sample.count) >= 0.004 {
+            return false
+        }
+
+        guard let text = String(data: sample, encoding: .isoLatin1) else { return false }
+        let lines = text.split(whereSeparator: \.isNewline)
+        guard lines.count >= 2 else { return false }
+
+        var nonWhitespace = 0
+        var letters = 0
+        for ch in text {
+            if ch.isWhitespace { continue }
+            nonWhitespace += 1
+            if ch.isLetter { letters += 1 }
+        }
+        guard nonWhitespace > 120 else { return false }
+
+        let letterRatio = Double(letters) / Double(nonWhitespace)
+        guard letterRatio > 0.52 else { return false }
+
+        let nonEmptyLines = lines.filter { !$0.isEmpty }
+        guard !nonEmptyLines.isEmpty else { return false }
+        let totalLen = nonEmptyLines.reduce(0) { $0 + $1.count }
+        let avgLineLen = totalLen / nonEmptyLines.count
+
+        return letterRatio > 0.52 && avgLineLen > 42
+    }
+}

--- a/Sources/AnsiSaver/ArtSource.swift
+++ b/Sources/AnsiSaver/ArtSource.swift
@@ -26,7 +26,12 @@ class FolderSource: ArtSource {
                 let ext = (name as NSString).pathExtension.lowercased()
                 return ansiExtensions.contains(ext)
             }
-            .map { (folderPath as NSString).appendingPathComponent($0) }
+            .compactMap { name -> String? in
+                let path = (folderPath as NSString).appendingPathComponent(name)
+                guard let data = Cache.read(path) else { return nil }
+                guard AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: name) else { return nil }
+                return path
+            }
 
         completion(paths)
     }
@@ -57,8 +62,15 @@ class PackSource: ArtSource {
                 let localPath = Cache.ansPath(forPack: packName, file: filename)
 
                 if Cache.exists(localPath) {
-                    queue.sync { localPaths.append(localPath) }
-                    continue
+                    if let data = Cache.read(localPath),
+                       AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: filename) {
+                        queue.sync { localPaths.append(localPath) }
+                    } else {
+                        try? FileManager.default.removeItem(atPath: localPath)
+                    }
+                    if Cache.exists(localPath) {
+                        continue
+                    }
                 }
 
                 group.enter()
@@ -97,17 +109,26 @@ class URLSource: ArtSource {
 
         for urlString in fileURLs {
             let localPath = Cache.urlCachePath(for: urlString)
+            let remoteName = URL(string: urlString)?.lastPathComponent ?? "download.ans"
 
             if Cache.exists(localPath) {
-                queue.sync { localPaths.append(localPath) }
-                continue
+                if let data = Cache.read(localPath),
+                   AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: remoteName) {
+                    queue.sync { localPaths.append(localPath) }
+                } else {
+                    try? FileManager.default.removeItem(atPath: localPath)
+                }
+                if Cache.exists(localPath) {
+                    continue
+                }
             }
 
             guard let url = URL(string: urlString) else { continue }
 
             group.enter()
             let task = URLSession.shared.dataTask(with: url) { data, _, error in
-                if let data = data, error == nil {
+                if let data = data, error == nil,
+                   AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: remoteName) {
                     Cache.write(data, to: localPath)
                     queue.sync { localPaths.append(localPath) }
                 }

--- a/Sources/AnsiSaver/PackFetcher.swift
+++ b/Sources/AnsiSaver/PackFetcher.swift
@@ -49,6 +49,11 @@ enum PackFetcher {
                 return
             }
 
+            guard AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: filename) else {
+                completion(false)
+                return
+            }
+
             Cache.write(data, to: localPath)
             completion(true)
         }

--- a/Tests/AnsiSaverTests/AnsiContentValidatorTests.swift
+++ b/Tests/AnsiSaverTests/AnsiContentValidatorTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+final class AnsiContentValidatorTests: XCTestCase {
+
+    func testBinaryExtensionsAlwaysAccepted() {
+        let data = Data("plain ascii without escapes".utf8)
+        XCTAssertTrue(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "art.ice"))
+        XCTAssertTrue(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "dump.bin"))
+    }
+
+    func testAnsiEscapeAccepted() {
+        let data = Data("\u{1b}[0;31mHello\u{1b}[0m\n".utf8)
+        XCTAssertTrue(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "readme.txt"))
+        XCTAssertTrue(AnsiContentValidator.hasAnsiEscapeOrCP437Art(data))
+    }
+
+    func testCP437HighBytesAccepted() {
+        var bytes = Data()
+        // Repeat block-drawing / CP437 bytes (0xB3 = ³ in CP437)
+        bytes.append(contentsOf: repeatElement(0xB3, count: 40))
+        XCTAssertTrue(AnsiContentValidator.isLikelyAnsiArt(data: bytes, fileName: "border.asc"))
+    }
+
+    func testPlainTxtRejectedWithoutAnsiSignals() {
+        let prose = """
+        RELEASE NOTES
+
+        This is a long readme-style document with many words explaining the archive.
+        It continues for several lines with normal prose and no ANSI escape codes.
+        """
+        let data = Data(prose.utf8)
+        XCTAssertFalse(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "readme.txt"))
+    }
+
+    func testPlainNfoRejectedWithoutAnsiSignals() {
+        let nfo = (0..<40).map { _ in
+            "NFO LINE: This is typical scene info text without color codes or block characters."
+        }.joined(separator: "\n")
+        let data = Data(nfo.utf8)
+        XCTAssertFalse(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "file-id.nfo"))
+    }
+
+    func testMislabeledAnsProseRejected() {
+        let prose = (0..<50).map { _ in
+            "Documentation line that looks like a readme saved with a wrong extension."
+        }.joined(separator: "\n")
+        let data = Data(prose.utf8)
+        XCTAssertFalse(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "logo.ans"))
+    }
+
+    func testAsciiArtWithoutEscapesStillAccepted() {
+        let ascii = """
+          ____
+         /    \\
+        |      |
+         \\____/
+        """
+        let data = Data(ascii.utf8)
+        XCTAssertTrue(AnsiContentValidator.isLikelyAnsiArt(data: data, fileName: "pic.asc"))
+    }
+}


### PR DESCRIPTION
## Summary

Occasionally the screensaver would show **readme-style `.txt` / `.nfo` content** (or prose mislabeled as `.ans`) instead of real ANSI/CP437 art. This adds a **content check** before files are cached or included in the rotation.

## Changes

- **`AnsiContentValidator`**: Accept binary art extensions (`.ice`, `.bin`, `.xb`, `.pcb`, `.adf`) as before; require ANSI escape sequences or CP437 (high-byte) density for text-like files; reject `.txt` / `.nfo` without art signals; use a light prose heuristic for mislabeled `.ans` / `.asc`.
- **`PackFetcher`**: Validate downloaded pack bytes before writing cache.
- **`ArtSource`**: Validate local folder files; revalidate cached pack/URL files and remove invalid cache entries; use URL `lastPathComponent` for extension hints on direct URL downloads.
- **Tests**: `AnsiContentValidatorTests`.
- **Xcode**: Shared `AnsiSaver` scheme with a **Test** action so `⌘U` / `xcodebuild -scheme AnsiSaver test` runs the unit tests.

## Verification

- `xcodebuild -scheme AnsiSaver -destination 'platform=macOS' test` (with `git submodule update --init` and Homebrew `gd` per README) — all tests pass.

---

Happy to adjust the heuristics if you hit edge cases (e.g. unusual ASCII-only art).